### PR TITLE
Updated Dockerfile to have a password

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,8 @@ RUN a2enmod rewrite
 
 RUN service postgresql start && sleep 3 && \
     su postgres -c "createuser airship" && \
-    su postgres -c "createdb -O airship airship"
+    su postgres -c "createdb -O airship airship" && \
+    su postgres -c "psql -c \"ALTER USER airship PASSWORD 'secret'\""
 
 COPY . /var/www/airship
 WORKDIR /var/www/airship


### PR DESCRIPTION
### Summary
Since were using network sockets for database connections we cannot peer authenticate, so our DB user needs a password. `secret` will work for now.


### Issues Addressed (Optional)
Contributing to #42


## Contributor Agreement (Required)

I am submitting this pull request under one or more of the following
licenses:

- [ ] [CC0 - No Rights Reserved](https://creativecommons.org/publicdomain/zero/1.0/)
- [x] [MIT License](https://opensource.org/licenses/MIT)
- [ ] [WTFPL](http://www.wtfpl.net/txt/copying/)

Furthermore, I understand that CMS Airship is released under the GNU Public
License to the general public, as well as private commercial licenses 
(purchasable from [Paragon Initiative Enterprises](https://paragonie.com)).

By submitting this pull request, I acknowledge that my contribution will be
incorporated into CMS Airship, and consent for it to be handled as outlined
above.

(This does not in any way restrict your rights to use your own modifications.
The purpose of this agreement is to maximize awareness and transparency.) 

