### PR TITLE
Switch to docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,19 @@
+version: '2'
+services:
+    database:
+        build:
+            context: .
+            dockerfile: docker/Dockerfile.pgsql
+    airship:
+        build:
+            context: .
+            dockerfile: docker/Dockerfile.airship
+
+        ports:
+            - "8080:80"
+
+        depends_on:
+            - database
+
+        links:
+            - database

--- a/docker/Dockerfile.airship
+++ b/docker/Dockerfile.airship
@@ -24,11 +24,6 @@ RUN phpenmod libsodium
 
 RUN a2enmod rewrite
 
-RUN service postgresql start && sleep 3 && \
-    su postgres -c "createuser airship" && \
-    su postgres -c "createdb -O airship airship" && \
-    su postgres -c "psql -c \"ALTER USER airship PASSWORD 'secret'\""
-
 COPY . /var/www/airship
 WORKDIR /var/www/airship
 RUN composer install --no-dev
@@ -58,5 +53,4 @@ ENV APACHE_RUN_DIR /var/run/apache2
 ENV APACHE_LOCK_DIR /var/lock/apache2
 ENV APACHE_LOG_DIR /var/log/apache2
 
-CMD ["bash", "-c", "service postgresql start & apache2 -D FOREGROUND"]
-
+CMD ["apache2", "-D", "FOREGROUND"]

--- a/docker/Dockerfile.pgsql
+++ b/docker/Dockerfile.pgsql
@@ -1,0 +1,3 @@
+FROM postgres:9.5
+
+COPY docker/pgsql/init.sh /docker-entrypoint-initdb.d/init.sh

--- a/docker/pgsql/init.sh
+++ b/docker/pgsql/init.sh
@@ -1,0 +1,3 @@
+su postgres -c "createuser airship"
+su postgres -c "createdb -O airship airship"
+su postgres -c "psql -c \"ALTER USER airship PASSWORD 'secret'\""


### PR DESCRIPTION
### Summary

Docker containers should run one service each. Docker compose manages multiple
containers and their dependencies. This change allows also to have a
persistent Postgres container, while only the Airship container is updated
most of the time.

If you want a fast recreate process, run `composer install` before running
`docker-compose up`. This will speed up the (repeated) build process
significantly, because dependencies are only pulled once instead of in every
single build.

### Issues Addressed (Optional)

- #42 

## Contributor Agreement (Required)

I am submitting this pull request under one or more of the following
licenses:

- [ ] [CC0 - No Rights Reserved](https://creativecommons.org/publicdomain/zero/1.0/)
- [x] [MIT License](https://opensource.org/licenses/MIT)
- [ ] [WTFPL](http://www.wtfpl.net/txt/copying/)

Furthermore, I understand that CMS Airship is released under the GNU Public
License to the general public, as well as private commercial licenses 
(purchasable from [Paragon Initiative Enterprises](https://paragonie.com)).

By submitting this pull request, I acknowledge that my contribution will be
incorporated into CMS Airship, and consent for it to be handled as outlined
above.

(This does not in any way restrict your rights to use your own modifications.
The purpose of this agreement is to maximize awareness and transparency.) 