### PR TITLE
Reduced complexity of docker-compose setup

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,9 +1,10 @@
 version: '2'
 services:
     database:
-        build:
-            context: .
-            dockerfile: docker/Dockerfile.pgsql
+        image: postgres:9.5
+        environment:
+            POSTGRES_PASSWORD: 'secret'
+            POSTGRES_USER: 'airship'    
     airship:
         build:
             context: .
@@ -17,3 +18,4 @@ services:
 
         links:
             - database
+

--- a/docker/Dockerfile.pgsql
+++ b/docker/Dockerfile.pgsql
@@ -1,3 +1,0 @@
-FROM postgres:9.5
-
-COPY docker/pgsql/init.sh /docker-entrypoint-initdb.d/init.sh

--- a/docker/pgsql/init.sh
+++ b/docker/pgsql/init.sh
@@ -1,3 +1,0 @@
-su postgres -c "createuser airship"
-su postgres -c "createdb -O airship airship"
-su postgres -c "psql -c \"ALTER USER airship PASSWORD 'secret'\""


### PR DESCRIPTION
### Summary
The psql docker image already has an option for user/password. Also, the database appears to be create automagically when type the database name in the Installer portion. The Installer settings you should use are as follows: 

Host:database 
Port:blank 
User:airship 
Password:secret 
Database:airship

The users may change the password to a "strong" one by changing the password in the docker-compose.yml file.

In the future it would be nice to share the psql socket between the two containers, in this way the two dockers could communicate over unix sockets rather than tcp ports, which are emulated in docker anyway.

It is noted however that it should be reasonably safe to run without a "strong password" since the server database ports are only to other docker containers that are linked. This means an attacker would need administrative access to the docker service in order to attack it or the image itself. Which is much like getting root, not a lot we can do there.

## Contributor Agreement (Required)

I am submitting this pull request under one or more of the following
licenses:

- [ ] [CC0 - No Rights Reserved](https://creativecommons.org/publicdomain/zero/1.0/)
- [x] [MIT License](https://opensource.org/licenses/MIT)
- [ ] [WTFPL](http://www.wtfpl.net/txt/copying/)

Furthermore, I understand that CMS Airship is released under the GNU Public
License to the general public, as well as private commercial licenses 
(purchasable from [Paragon Initiative Enterprises](https://paragonie.com)).

By submitting this pull request, I acknowledge that my contribution will be
incorporated into CMS Airship, and consent for it to be handled as outlined
above.

(This does not in any way restrict your rights to use your own modifications.
The purpose of this agreement is to maximize awareness and transparency.) 
