### PR TITLE
Update Psalm and add stubfiles to avoid TooFewArguments

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -3845,12 +3845,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/vimeo/psalm.git",
-                "reference": "b1b7b0ae3557b0c558487a862e0c7a3302b6240c"
+                "reference": "7ed188fa525834a6d76de8d0d7b2003db63d564a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/vimeo/psalm/zipball/b1b7b0ae3557b0c558487a862e0c7a3302b6240c",
-                "reference": "b1b7b0ae3557b0c558487a862e0c7a3302b6240c",
+                "url": "https://api.github.com/repos/vimeo/psalm/zipball/7ed188fa525834a6d76de8d0d7b2003db63d564a",
+                "reference": "7ed188fa525834a6d76de8d0d7b2003db63d564a",
                 "shasum": ""
             },
             "require": {
@@ -3886,7 +3886,7 @@
                 "inspection",
                 "php"
             ],
-            "time": "2017-03-18 20:34:44"
+            "time": "2017-03-19T19:41:24+00:00"
         },
         {
             "name": "webmozart/assert",

--- a/psalm.xml
+++ b/psalm.xml
@@ -7,9 +7,10 @@
     <projectFiles>
         <directory name="src/Engine" />
     </projectFiles>
+    <stubs>
+        <file name="vendor/paragonie/halite/stub/Sodium.stub.php" />
+    </stubs>
     <issueHandlers>
-        <TooFewArguments errorLevel="info" />
-        <!-- Psalm doesn't recognize this correctly -->
         <TooManyArguments errorLevel="info" />
         <!-- Psalm doesn't recognize this correctly -->
         <UndefinedConstant errorLevel="info" />


### PR DESCRIPTION
### Summary

I've just added stub file support for function declarations inside conditionals.

This PR bumps the Psalm version and adds the stub file to the config.

## Contributor Agreement (Required)

I am submitting this pull request under one or more of the following
licenses:

- [x] [CC0 - No Rights Reserved](https://creativecommons.org/publicdomain/zero/1.0/)
- [x] [MIT License](https://opensource.org/licenses/MIT)
- [x] [WTFPL](http://www.wtfpl.net/txt/copying/)

Furthermore, I understand that CMS Airship is released under the GNU Public
License to the general public, as well as private commercial licenses 
(purchasable from [Paragon Initiative Enterprises](https://paragonie.com)).

By submitting this pull request, I acknowledge that my contribution will be
incorporated into CMS Airship, and consent for it to be handled as outlined
above.

(This does not in any way restrict your rights to use your own modifications.
The purpose of this agreement is to maximize awareness and transparency.) 