### PR TITLE
Add support for reflected variadic parameters

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -3845,12 +3845,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/vimeo/psalm.git",
-                "reference": "7ed188fa525834a6d76de8d0d7b2003db63d564a"
+                "reference": "fc4a72d9054d46c5f9aac8340deba829a69f4a44"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/vimeo/psalm/zipball/7ed188fa525834a6d76de8d0d7b2003db63d564a",
-                "reference": "7ed188fa525834a6d76de8d0d7b2003db63d564a",
+                "url": "https://api.github.com/repos/vimeo/psalm/zipball/fc4a72d9054d46c5f9aac8340deba829a69f4a44",
+                "reference": "fc4a72d9054d46c5f9aac8340deba829a69f4a44",
                 "shasum": ""
             },
             "require": {
@@ -3886,7 +3886,7 @@
                 "inspection",
                 "php"
             ],
-            "time": "2017-03-19 19:41:24"
+            "time": "2017-03-19T22:31:19+00:00"
         },
         {
             "name": "webmozart/assert",

--- a/src/Engine/Continuum/Channel.php
+++ b/src/Engine/Continuum/Channel.php
@@ -59,7 +59,6 @@ class Channel
      * @param string $name
      * @param array $config
      * @throws \TypeError
-     * @psalm-suppress TooManyArguments Because it's variadic...
      */
     public function __construct($parent, string $name, array $config = [])
     {

--- a/src/Engine/Database.php
+++ b/src/Engine/Database.php
@@ -518,7 +518,6 @@ class Database implements DBInterface
      *
      * @throws DBAlert\DBException
      * @throws \TypeError
-     * @psalm-suppress TooManyArguments Because it's variadic...
      */
     public function insertGet(string $table, array $map, string $field)
     {

--- a/src/Engine/Security/CSRF.php
+++ b/src/Engine/Security/CSRF.php
@@ -179,7 +179,6 @@ class CSRF
      * @param array $options
      * @throws InvalidConfig
      * @return void
-     * @psalm-suppress TooManyArguments Because it's variadic...
      */
     public function reconfigure(array $options = []): void
     {


### PR DESCRIPTION
### Summary

I updated Psalm to avoid the issue whereby it was failing to see `trk`'s variadic parameter – `trk` having been loaded in the autoloading script, so ingested via reflection.

## Contributor Agreement (Required)

I am submitting this pull request under one or more of the following
licenses:

- [x] [CC0 - No Rights Reserved](https://creativecommons.org/publicdomain/zero/1.0/)
- [x] [MIT License](https://opensource.org/licenses/MIT)
- [x] [WTFPL](http://www.wtfpl.net/txt/copying/)

Furthermore, I understand that CMS Airship is released under the GNU Public
License to the general public, as well as private commercial licenses 
(purchasable from [Paragon Initiative Enterprises](https://paragonie.com)).

By submitting this pull request, I acknowledge that my contribution will be
incorporated into CMS Airship, and consent for it to be handled as outlined
above.

(This does not in any way restrict your rights to use your own modifications.
The purpose of this agreement is to maximize awareness and transparency.) 