### PR TITLE
Fix #94: Redirect PHP-FPM error logs to stderr

### DIFF
--- a/docker/Dockerfile.airship
+++ b/docker/Dockerfile.airship
@@ -35,6 +35,9 @@ RUN echo "<VirtualHost *:80>" > $CONF && \
     echo "</Directory>" >> $CONF && \
     echo "</VirtualHost>" >> $CONF
 
+# make php-fpm log to STDERR so docker logs sees PHP's error logging
+RUN ln -s /dev/stderr /var/log/php7.2-fpm.log
+
 ENV APACHE_RUN_USER www-data
 ENV APACHE_RUN_GROUP www-data
 ENV APACHE_PID_FILE /var/run/apache2/apache2.pid


### PR DESCRIPTION
### Summary

This change symlinks the default PHP error log file to /dev/stderr so that `docker logs` will also include PHP errors from the airship application container. Currently, only Apache routes logs to stderr.

Note: this fix will break on major or minor (x or x.x) PHP version changes (because the log file path will change). If this is a concern, then I'll find ways to fix it before this gets merged.
 
### Issues Addressed (Optional)

#94 Docker PHP Logs

## Contributor Agreement (Required)

I am submitting this pull request under one or more of the following
licenses:

- [x] [CC0 - No Rights Reserved](https://creativecommons.org/publicdomain/zero/1.0/)
- [x] [MIT License](https://opensource.org/licenses/MIT)
- [x] [WTFPL](http://www.wtfpl.net/txt/copying/)

Furthermore, I understand that CMS Airship is released under the GNU Public
License to the general public, as well as private commercial licenses 
(purchasable from [Paragon Initiative Enterprises](https://paragonie.com)).

By submitting this pull request, I acknowledge that my contribution will be
incorporated into CMS Airship, and consent for it to be handled as outlined
above.

(This does not in any way restrict your rights to use your own modifications.
The purpose of this agreement is to maximize awareness and transparency.) 

### Labels Requested

none