### PR TITLE
Use `Never` return type to declare function call is guaranteed to end program execution

### DIFF
--- a/src/Cabin/Hull/Controller/PublicFiles.php
+++ b/src/Cabin/Hull/Controller/PublicFiles.php
@@ -8,6 +8,7 @@ use Airship\Alerts\{
     Router\ControllerComplete,
     Router\EmulatePageNotFound
 };
+use Airship\Engine\Contract\Never;
 use Airship\Engine\Model;
 use Airship\Engine\Security\Util;
 
@@ -59,12 +60,12 @@ class PublicFiles extends ControllerGear
      *
      * @param string $path
      * @param string $default Default MIME type
-     * @return void
+     * @return Never
      * @route files/(.*)
      * @throws ControllerComplete
      * @throws EmulatePageNotFound
      */
-    public function download(string $path, string $default = 'text/plain'): void
+    public function download(string $path, string $default = 'text/plain'): Never
     {
         if (!$this->can('read')) {
             throw new EmulatePageNotFound();
@@ -109,11 +110,13 @@ class PublicFiles extends ControllerGear
             }
             \readfile($realPath);
             exit;
+            return new Never;
         } catch (FileNotFound $ex) {
             // When all else fails, 404 not found
             \http_response_code(404);
             $this->view('404');
             exit(1);
+            return new Never;
         }
     }
 

--- a/src/CommandLine/installer.php
+++ b/src/CommandLine/installer.php
@@ -7,6 +7,7 @@ use Airship\Engine\Continuum\Installers\{
     Motif
 };
 use Airship\Engine\State;
+use Airship\Engine\Contract\Never;
 use ParagonIE\ConstantTime\Binary;
 
 require_once \dirname(__DIR__).'/bootstrap.php';
@@ -14,7 +15,7 @@ require_once \dirname(__DIR__).'/bootstrap.php';
 /**
  * Show the usage
  */
-function usage()
+function usage(): Never
 {
     echo 'Command Line Extension Installer - Usage:', "\n";
     echo 'To download from the Internet:', "\n\t";

--- a/src/CommandLine/manual_update.php
+++ b/src/CommandLine/manual_update.php
@@ -8,6 +8,7 @@ use Airship\Engine\Continuum\Updaters\{
     Motif
 };
 use Airship\Engine\State;
+use Airship\Engine\Contract\Never;
 use ParagonIE\ConstantTime\Binary;
 
 require_once \dirname(__DIR__).'/bootstrap.php';
@@ -15,7 +16,7 @@ require_once \dirname(__DIR__).'/bootstrap.php';
 /**
  * Show the usage
  */
-function usage()
+function usage(): Never
 {
     echo 'Command Line Extension Updater - Usage:', "\n";
     echo 'To download from the Internet:', "\n\t";

--- a/src/Engine/AutoPilot.php
+++ b/src/Engine/AutoPilot.php
@@ -8,7 +8,10 @@ use Airship\Alerts\Router\{
     FallbackLoop,
     ControllerComplete
 };
-use Airship\Engine\Contract\RouterInterface;
+use Airship\Engine\Contract\{
+    RouterInterface,
+    Never
+};
 use Airship\Engine\Security\Util;
 
 use ParagonIE\ConstantTime\Binary;
@@ -513,9 +516,9 @@ class AutoPilot implements RouterInterface
 
     /**
      * @param null|ResponseInterface $response
-     * @return void
+     * @return Never
      */
-    public function serveResponse(?ResponseInterface $response = null): void
+    public function serveResponse(?ResponseInterface $response = null): Never
     {
         if (empty($response)) {
             $response = $this->getController()
@@ -530,6 +533,7 @@ class AutoPilot implements RouterInterface
         }
         echo (string) $response->getBody();
         exit(0);
+        return new Never;
     }
 
     /**

--- a/src/Engine/Contract/Never.php
+++ b/src/Engine/Contract/Never.php
@@ -1,0 +1,14 @@
+<?php
+declare(strict_types=1);
+namespace Airship\Engine\Contract;
+
+/**
+ * No return
+ */
+final class Never
+{
+    public function __construct()
+    {
+        throw new \TypeError(__CLASS__.' is not constructable');
+    }
+}


### PR DESCRIPTION
### Summary
Inspired heavily by the introduction of this in [Swift's standard library](https://github.com/apple/swift-evolution/blob/master/proposals/0102-noreturn-bottom-type.md), introduce a non-constructible `Never` type to enforce that functions that are intended to end program execution actually do (not doing so would be a type error).


### Issues Addressed (Optional)
n/a


## Contributor Agreement (Required)

I am submitting this pull request under one or more of the following
licenses:

- [ ] [CC0 - No Rights Reserved](https://creativecommons.org/publicdomain/zero/1.0/)
- [x] [MIT License](https://opensource.org/licenses/MIT)
- [ ] [WTFPL](http://www.wtfpl.net/txt/copying/)

Furthermore, I understand that CMS Airship is released under the GNU Public
License to the general public, as well as private commercial licenses 
(purchasable from [Paragon Initiative Enterprises](https://paragonie.com)).

By submitting this pull request, I acknowledge that my contribution will be
incorporated into CMS Airship, and consent for it to be handled as outlined
above.

(This does not in any way restrict your rights to use your own modifications.
The purpose of this agreement is to maximize awareness and transparency.) 

### Labels Requested

Feel free to list any labels you feel are appropriate for this issue,
and a member of the Airship core team will apply them as soon as 
possible.

* `feedback-sought`
* `documentation`