### PR TITLE
Fix broken documentation links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,7 +72,7 @@
     different input formats.
   * [#146](https://github.com/paragonie/airship/issues/146):
     Created a button to purge the caches.
-  * Hid the link to view blog post history, as that feature was 
+  * Hid the link to view blog post history, as that feature was
     overlooked. We'll implement it in version 1.4.0.
   * Some image types can be viewed directly instead of always forcing a
     download. The enforcement logic is a whitelist (that gadgets can
@@ -83,7 +83,7 @@
   * Significant UI/UX improvements.
     * Redesigned the Bridge UI to be more suitable for a control panel.
     * The left menu in the Bridge is now collapsable, but automatically
-      opens the sections which indicate your current location in the 
+      opens the sections which indicate your current location in the
       cabin.
   * Update [Halite](https://github.com/paragonie/halite) to 2.2.0.
   * Added a `WhiteList` filter, which is a strict typed alternative to
@@ -142,7 +142,7 @@
 ## Version 1.2.2 - 2016-07-13
 
   * Improved Continuum/Keyggdrasil logging.
-  * Created a tool for automating step one of the installer from the command 
+  * Created a tool for automating step one of the installer from the command
     line.
 
 ## Version 1.2.1 - 2016-07-09
@@ -173,10 +173,10 @@
     Added a faster install option for deploying an Airship in a hurry, with the
     sane defaults we provide.
   * [#77](https://github.com/paragonie/airship/issues/77):
-    Fixed responsive UI/UX warts (i.e. small links and buttons). 
+    Fixed responsive UI/UX warts (i.e. small links and buttons).
   * [#80](https://github.com/paragonie/airship/issues/80):
     If the GD extension isn't loaded, render QR codes for two-factor
-    authentication as SVG instead. 
+    authentication as SVG instead.
   * [#88](https://github.com/paragonie/airship/issues/88):
     The installer now uses Zxcvbn to enforce a minimum password strength for
     administrator accounts.
@@ -189,12 +189,12 @@
 
   * i18n - run parameters through HTMLPurifier (with caching) to prevent future
     XSS payloads in case someone forgets to escape these parameters. HTML is
-    still allowed, so if you're inserting in an HTML attribute, use the 
+    still allowed, so if you're inserting in an HTML attribute, use the
     `|e('html_attr')` filter on your input.
   * Use the correct POST index in account recovery.
   * Treat SVG and XML files as plaintext, to prevent stored XSS. Reported on
     [HackerOne](https://hackerone.com/reports/148853).
-  * Send `Content-Security-Policy` headers on file downloads as well as web 
+  * Send `Content-Security-Policy` headers on file downloads as well as web
     pages. Just in case another file type exists in the world that executes
     JavaScript when the file is viewed.
 
@@ -216,7 +216,7 @@
 
   Fixes for bugs reported by [@kelunik](https://github.com/kelunik) and
   [@co60ca](https://github.com/co60ca).
-  
+
   * [#61](https://github.com/paragonie/airship/issues/61):
     Comments need a min-height attribute.
   * [#62](https://github.com/paragonie/airship/issues/62), [#64](https://github.com/paragonie/airship/issues/64):
@@ -310,7 +310,7 @@
   * Implemented input filters which work on multidimensional arrays (e.g
     `$_POST`). We provide a few examples (one for each cabin's custom config
     and one for the universal config).
-  * Implemented optional **Two-Factor Authentication** support via TOTP 
+  * Implemented optional **Two-Factor Authentication** support via TOTP
     (e.g. Google Authenticator).
   * Airship now supports in-memory caching via APCu instead of the filesystem.
   * Comments are now loaded with AJAX when you elect to cache a blog post.
@@ -353,7 +353,7 @@
   * Users can now selected uploaded image files to use for biography images and
     avatars to accompany their blog comments.
   * Lots of reorganization, refactoring, and clean-up.
-  * Moved the [CMS Airship Documentation](https://github.com/paragonie/airship-docs)
+  * Moved the [CMS Airship Documentation](https://github.com/paragonie/airship/tree/master/docs)
     to its own dedicated git repository.
   * When you change a blog post's slug, you can optionally create an HTTP 301
     redirect to the new URL to prevent visitors from getting an unfortunate

--- a/README.md
+++ b/README.md
@@ -18,13 +18,13 @@ if your company requires an alternative to the GNU Public License.
 
 ## Benefits of CMS Airship
 
-1. [**Digitally signed automatic security updates.**](https://github.com/paragonie/airship-docs/blob/master/en-us/WHY.md#1-digitally-signed-automatic-security-updates)
-2. [Community first.](https://github.com/paragonie/airship-docs/blob/master/en-us/WHY.md#2-the-community-is-always-in-control-of-any-add-ons-it-produces)
+1. [**Digitally signed automatic security updates.**](https://github.com/paragonie/airship/tree/master/docs/en-us/WHY.md#1-digitally-signed-automatic-security-updates)
+2. [Community first.](https://github.com/paragonie/airship/tree/master/docs/en-us/WHY.md#2-the-community-is-always-in-control-of-any-add-ons-it-produces)
    The community is always in control of any add-ons it produces. No one
    can backdoor your extensions without your signing keys.
-3. [Supports a multi-site architecture out of the box.](https://github.com/paragonie/airship-docs/blob/master/en-us/WHY.md#3-supports-a-multi-site-architecture-out-of-the-box)
-4. [Designed by progressive-minded application security professionals.](https://github.com/paragonie/airship-docs/blob/master/en-us/WHY.md#4-designed-by-progressive-minded-application-security-professionals)
-5. [Fully customizable and extensible.](https://github.com/paragonie/airship-docs/blob/master/en-us/WHY.md#5-our-gear-system-allows-the-framework-to-be-extended)
+3. [Supports a multi-site architecture out of the box.](https://github.com/paragonie/airship/tree/master/docs/en-us/WHY.md#3-supports-a-multi-site-architecture-out-of-the-box)
+4. [Designed by progressive-minded application security professionals.](https://github.com/paragonie/airship/tree/master/docs/en-us/WHY.md#4-designed-by-progressive-minded-application-security-professionals)
+5. [Fully customizable and extensible.](https://github.com/paragonie/airship/tree/master/docs/en-us/WHY.md#5-our-gear-system-allows-the-framework-to-be-extended)
    Our `Gears` system allows extensions to easily restructure and/or
    replace entire Airship features without causing conflicts with our
    secure automatic updating process.
@@ -44,20 +44,20 @@ The [CMS Airship Documentation](https://github.com/paragonie/airship/tree/master
 
 ### Getting Started
 
- * [Five-minute overview of CMS Airship](https://github.com/paragonie/airship-docs/blob/master/en-us/5-Minute-Overview.md)
- * [Introduction](https://github.com/paragonie/airship-docs/tree/master/en-us/01-intro)
- * [How to install CMS Airship](https://github.com/paragonie/airship-docs/blob/master/en-us/01-intro/2-Installing.md)
+ * [Five-minute overview of CMS Airship](https://github.com/paragonie/airship/tree/master/docs/en-us/5-Minute-Overview.md)
+ * [Introduction](https://github.com/paragonie/airship/tree/master/docs/en-us/01-intro)
+ * [How to install CMS Airship](https://github.com/paragonie/airship/tree/master/docs/en-us/01-intro/2-Installing.md)
 
 ## Customizing Your Airship
 
-CMS Airship extensions come in three flavors ([detailed explanations](https://github.com/paragonie/airship-docs/blob/master/en-us/01-intro/1-Lingo-Jargon.md#airship-extension-types)):
+CMS Airship extensions come in three flavors ([detailed explanations](https://github.com/paragonie/airship/tree/master/docs/en-us/01-intro/1-Lingo-Jargon.md#airship-extension-types)):
 
 * **Cabins**: self-contained applications
 * **Gadgets**: alters the functionality of an existing Cabin (or of the
   Engine itself)
 * **Motifs**: alters the apperance of an existing Cabin
 
-To create and/or manage these extensions, check out 
+To create and/or manage these extensions, check out
 [barge, our command line utility](https://github.com/paragonie/airship-barge).
 
 ### Screenshot
@@ -67,6 +67,6 @@ To create and/or manage these extensions, check out
 Airship is fully mobile responsive thanks to the [Pure CSS framework](http://purecss.io/).
 See it in action at [CSPR.NG](https://cspr.ng).
 
-## Contributing to CMS Airship  
+## Contributing to CMS Airship
 
 * See [CONTRIBUTING.md](https://github.com/paragonie/airship/blob/master/.github/CONTRIBUTING.md)

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     "email": "security@paragonie.com",
     "issues": "https://github.com/paragonie/airship/issues",
     "source": "https://github.com/paragonie/airship",
-    "docs": "https://github.com/paragonie/airship-docs"
+    "docs": "https://github.com/paragonie/airship/tree/master/docs"
   },
   "keywords": [
     "Airship",

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,9 +1,9 @@
 # CMS Airship Documentation
 
 This contains the documentation for [CMS Airship](https://github.com/paragonie/airship).
-The documentation is available under the CC0 license for free at 
-[https://github.com/paragonie/airship-docs](https://github.com/paragonie/airship-docs).
+The documentation is available under the CC0 license for free at
+[https://github.com/paragonie/airship/tree/master/docs](https://github.com/paragonie/airship/tree/master/docs).
 
 ### Languages
 
-* [English (U.S.)](https://github.com/paragonie/airship-docs/tree/master/en-us)
+* [English (U.S.)](https://github.com/paragonie/airship/tree/master/docs/en-us)

--- a/docs/en-us/01-intro/2-Installing.md
+++ b/docs/en-us/01-intro/2-Installing.md
@@ -63,7 +63,7 @@ Run these commands to get PHP 7 installed. These instructions assume you have Ub
         echo -e "\033[33mDownloading PGP Public Key...\033[0m"
         gpg --recv-keys 6572BBEF1B5FF28B28B706837E3F070089DF5277
         # http://pgp.mit.edu/pks/lookup?op=vindex&fingerprint=on&search=0x6572BBEF1B5FF28B28B706837E3F070089DF5277
-        # DotDeb Signing Key 
+        # DotDeb Signing Key
         gpg --fingerprint 6572BBEF1B5FF28B28B706837E3F070089DF5277
         if [ $? -ne 0 ]; then
             echo -e "\033[31mCould not download PGP public key for verification\033[0m"
@@ -71,17 +71,17 @@ Run these commands to get PHP 7 installed. These instructions assume you have Ub
         fi
     fi
     gpg -a --export 6572BBEF1B5FF28B28B706837E3F070089DF5277 | sudo apt-key add -
-    
+
     # Install PHP from DotDeb
     sudo apt-get -y install php7.0 php7.0-cli php7.0-fpm php7.0-json php7.0-pgsql php7.0-curl php7.0-dev php7.0-mbstring php7.0-gd
     wget https://pear.php.net/go-pear.phar
-    
+
     # The PEAR team doesn't provide a GPG signature, so we have to do this:
     echo "8322214a6979a0917f0068af924428a80ff7083b94343396b13dac1d0f916748025fab72290af340d30633837222c277  go-pear.phar" | sha384sum -c
     if [ $? -eq 0 ]; then
         php go-pear.phar
     fi
-    
+
     sudo pecl install zip
     echo "extension=zip.so" > /etc/php/7.0/cli/conf.d/20-zip.ini
     echo "extension=zip.so" > /etc/php/7.0/fpm/conf.d/zip.ini
@@ -95,7 +95,7 @@ Run these commands to get PHP 7 installed. These instructions assume you have Ub
         echo -e "\033[33mDownloading PGP Public Key...\033[0m"
         gpg --recv-keys B97B0AFCAA1A47F044F244A07FCC7D46ACCC4CF8
         # http://pgp.mit.edu/pks/lookup?op=vindex&fingerprint=on&search=0xB97B0AFCAA1A47F044F244A07FCC7D46ACCC4CF8
-        # PostgreSQL Signing Key 
+        # PostgreSQL Signing Key
         gpg --fingerprint B97B0AFCAA1A47F044F244A07FCC7D46ACCC4CF8
         if [ $? -ne 0 ]; then
             echo -e "\033[31mCould not download PGP public key for verification\033[0m"
@@ -103,7 +103,7 @@ Run these commands to get PHP 7 installed. These instructions assume you have Ub
         fi
     fi
     gpg -a --export B97B0AFCAA1A47F044F244A07FCC7D46ACCC4CF8 | sudo apt-key add -
-    
+
     # Now. let's install PostgreSQL
     sudo apt-get update
     sudo apt-get install postgresql-9.5
@@ -188,13 +188,13 @@ If you haven't already done so, restart your webserver then visit the URL or IP
 address that corresponds to the active virtual host in your browser.
 
 Once you access the web installer, a security cookie is placed in your browser
-which prevents anyone from accessing the installer until the process is 
+which prevents anyone from accessing the installer until the process is
 finished. If you get locked out, run this command and reload
 the page. (You will have to start over, but the process is brief.)
 
     php src/Installer/launch.php reset
-    
+
 From this point, follow the prompts on the web-based installer and you'll be
 ready to take off.
 
-[Next: Basic Usage](https://github.com/paragonie/airship-docs/tree/master/en-us/02-basic-usage).
+[Next: Basic Usage](https://github.com/paragonie/airship/tree/master/docs/en-us/02-basic-usage).

--- a/docs/en-us/WHY.md
+++ b/docs/en-us/WHY.md
@@ -9,27 +9,27 @@
 
 ### 1. Digitally signed automatic security updates.
 
-Unlike other frameworks and content management systems, our authenticated 
+Unlike other frameworks and content management systems, our authenticated
 automatic security updating mechanism is a **first-class design decision**.
 
-If a security vulnerability is ever discovered in Airship, the patch 
+If a security vulnerability is ever discovered in Airship, the patch
 will automatically be applied in your website within an hour of being
 released by our team.
 
-All security updates will be digitally signed with a secret key to 
+All security updates will be digitally signed with a secret key to
 guarantee authenticity; the associated public key is packaged with the
 default Airship configuration. The digital signature algorithm we use is
 **`Ed25519`** (facilitated by libsodium).
 
 We take extra care when handling our secret key; should it ever be
-compromised, we will use our backup key to revoke the old one and 
+compromised, we will use our backup key to revoke the old one and
 replace it with a new one.
 
 You can disable the auto-update feature from the Bridge, but we do not
 recommend doing this.
 
-You can also choose to trust someone else's mirrors and public key 
-instead of ours. The code is completely open, but you only need change a 
+You can also choose to trust someone else's mirrors and public key
+instead of ours. The code is completely open, but you only need change a
 JSON configuration file to decide to trust someone else.
 
 ### 2. The community is always in control of any add-ons it produces.
@@ -37,17 +37,17 @@ JSON configuration file to decide to trust someone else.
 Airship offers three strategies for extending its base features:
 
 1. Cabins, which are entire applications (see #3 below).
-2. Gadgets, which are plugins that can be applied at a per-Cabin level 
+2. Gadgets, which are plugins that can be applied at a per-Cabin level
    or across every Cabin in your ship.
-3. Motifs, which change the look and feel of your Airship. 
+3. Motifs, which change the look and feel of your Airship.
 
 All Cabins, Gadgets, and Motifs can be assigned to a vendor (which has
-its own Ed25519 key pair), and that supplier has control of the 
+its own Ed25519 key pair), and that supplier has control of the
 distribution of automatic updates.
 
-**This gives you, the supplier, control over your add-ons**, not us. 
+**This gives you, the supplier, control over your add-ons**, not us.
 Neither the Airship development team nor Paragon Initiative Enterprises
-can prevent your users from installing, updating, or using any add-on. 
+can prevent your users from installing, updating, or using any add-on.
 
 We *can* still de-list abusive add-ons from the official SkyPort, but
 anyone can operate their own and we will always aspire to make switching
@@ -58,7 +58,7 @@ barriers to entry.
 
 ### 3. Supports a multi-site architecture out of the box.
 
-Each Cabin is its own website. Install as many Cabins as you need. No 
+Each Cabin is its own website. Install as many Cabins as you need. No
 questionable hacks needed.
 
 ### 4. Designed by progressive-minded application security professionals.
@@ -68,9 +68,9 @@ We specialize in application security and applied cryptography.
 
 ### 5. Our Gear system allows the framework to be extended.
 
-Because of our auto-updater, any local changes made to the Engine files 
+Because of our auto-updater, any local changes made to the Engine files
 will be obliterated whenever an upstream change occurs. To allow users
-to extend and customize the core classes to meet their needs, we 
+to extend and customize the core classes to meet their needs, we
 designed our application around the `Gears` system.
 
 Most of the core `Engine` classes can be extended at runtime by the
@@ -83,7 +83,7 @@ accessing the core classes directly, load the latest version of the Gear
 Compare, for example, [this long guide to securing WordPress](https://codex.wordpress.org/Hardening_WordPress)
 with our guide to securing Airship:
 
-1. Use TLS (if you use [Caddy](https://github.com/paragonie/airship-docs/blob/master/en-us/01-intro/2-Installing.md#caddy-recommended),
+1. Use TLS (if you use [Caddy](https://github.com/paragonie/airship/blob/master/docs/en-us/01-intro/2-Installing.md#caddy-recommended),
    this is automatic in production environments).
 2. Don't disable automatic updates.
 3. Use a strong password.
@@ -95,7 +95,7 @@ of Service attacks. Even if our infrastrucutre is compromised, your Airship is
 protected by [strong cryptography](https://paragonie.com/blog/2016/05/keyggdrasil-continuum-cryptography-powering-cms-airship).
 
 ### Vulnerabilities we Prevent
- 
+
 What follows is a list of security vulnerabilities you will almost certainly
 never have to worry about if you use CMS Airship.
 
@@ -103,7 +103,7 @@ never have to worry about if you use CMS Airship.
   * Airship uses a virtual filesystem that offers read-only access (and only
     to authorized users) to uploaded files. Files will never execute in the
     server nor in your browser.
-* **SQL Injection** is effectively mitigated by our use of prepared 
+* **SQL Injection** is effectively mitigated by our use of prepared
   statements in nearly every context. Where prepared statements aren't
   used, a typecast to int or strict whitelist of allowed characters is
   enforced instead.

--- a/docs/es-la/01-intro/2-Installing.md
+++ b/docs/es-la/01-intro/2-Installing.md
@@ -5,7 +5,7 @@
 Hay un archivo docker-compose.yml en [el repositorio principal](https://github.com/paragonie/airship) que usado junto con
 docker-compose construirá el software requerido. Leer [la documentaciòn oficial de docker](https://docs.docker.com/compose/overview/) para màs detalles sobre còmo utilizar docker-compose.
 
-## Instalación Manual 
+## Instalación Manual
 
 > Nota: Si tiene problemas al verificar las firmas GPG, puede que necesite
 > [cambiar la ruta de PGP](http://jotham-city.com/blog/2015/02/14/verifying-gpg-signatures-for-makepkg/).
@@ -63,7 +63,7 @@ Ejecute estos comandos para instalar PHP 7. Estas instrucciones asumn que tiene 
         echo -e "\033[33mDownloading PGP Public Key...\033[0m"
         gpg --recv-keys 6572BBEF1B5FF28B28B706837E3F070089DF5277
         # http://pgp.mit.edu/pks/lookup?op=vindex&fingerprint=on&search=0x6572BBEF1B5FF28B28B706837E3F070089DF5277
-        # DotDeb Signing Key 
+        # DotDeb Signing Key
         gpg --fingerprint 6572BBEF1B5FF28B28B706837E3F070089DF5277
         if [ $? -ne 0 ]; then
             echo -e "\033[31mCould not download PGP public key for verification\033[0m"
@@ -71,17 +71,17 @@ Ejecute estos comandos para instalar PHP 7. Estas instrucciones asumn que tiene 
         fi
     fi
     gpg -a --export 6572BBEF1B5FF28B28B706837E3F070089DF5277 | sudo apt-key add -
-    
+
     # Instalar PHP desde DotDeb
     sudo apt-get -y install php7.0 php7.0-cli php7.0-fpm php7.0-json php7.0-pgsql php7.0-curl php7.0-dev php7.0-mbstring php7.0-gd
     wget https://pear.php.net/go-pear.phar
-    
+
     # PEAR team no provee una firma GPG, así que tendremos que hacer ésto:
     echo "8322214a6979a0917f0068af924428a80ff7083b94343396b13dac1d0f916748025fab72290af340d30633837222c277  go-pear.phar" | sha384sum -c
     if [ $? -eq 0 ]; then
         php go-pear.phar
     fi
-    
+
     sudo pecl install zip
     echo "extension=zip.so" > /etc/php/7.0/cli/conf.d/20-zip.ini
     echo "extension=zip.so" > /etc/php/7.0/fpm/conf.d/zip.ini
@@ -95,7 +95,7 @@ Ejecute estos comandos para instalar PHP 7. Estas instrucciones asumn que tiene 
         echo -e "\033[33mDownloading PGP Public Key...\033[0m"
         gpg --recv-keys B97B0AFCAA1A47F044F244A07FCC7D46ACCC4CF8
         # http://pgp.mit.edu/pks/lookup?op=vindex&fingerprint=on&search=0xB97B0AFCAA1A47F044F244A07FCC7D46ACCC4CF8
-        # PostgreSQL Signing Key 
+        # PostgreSQL Signing Key
         gpg --fingerprint B97B0AFCAA1A47F044F244A07FCC7D46ACCC4CF8
         if [ $? -ne 0 ]; then
             echo -e "\033[31mCould not download PGP public key for verification\033[0m"
@@ -103,7 +103,7 @@ Ejecute estos comandos para instalar PHP 7. Estas instrucciones asumn que tiene 
         fi
     fi
     gpg -a --export B97B0AFCAA1A47F044F244A07FCC7D46ACCC4CF8 | sudo apt-key add -
-    
+
     # Ahora, a instalar PostgreSQL
     sudo apt-get update
     sudo apt-get install postgresql-9.5
@@ -188,13 +188,13 @@ Si no lo ha hecho todavía, reinicie su webserver y visite su URL o dirección I
 que corresponde al host virtual activo en su browser.
 
 Una vez que haya accedido al instalador,una cookie de seguridad es puesta en su navegador,
-la cual evita que cualquier otra persona entre al instalador hasta que el proceso haya 
+la cual evita que cualquier otra persona entre al instalador hasta que el proceso haya
 terminado. Si por alguna razón ha quedado fuera, ejecute este comando y refresque
 la página. (Tendrá que hacer todo de nuevo, pero el proceso no tarda mucho.)
 
     php src/Installer/launch.php reset
-    
+
 A partir de aquí, siga las instrucciones en el navegador y estará
 listo para despegar.
 
-[Siguiente: Uso Básico](https://github.com/paragonie/airship-docs/tree/master/en-us/02-basic-usage).
+[Siguiente: Uso Básico](https://github.com/paragonie/airship/tree/master/docs/en-us/02-basic-usage).

--- a/docs/es-la/WHY.md
+++ b/docs/es-la/WHY.md
@@ -9,27 +9,27 @@
 
 ### 1. Digitally signed automatic security updates.
 
-Unlike other frameworks and content management systems, our authenticated 
+Unlike other frameworks and content management systems, our authenticated
 automatic security updating mechanism is a **first-class design decision**.
 
-If a security vulnerability is ever discovered in Airship, the patch 
+If a security vulnerability is ever discovered in Airship, the patch
 will automatically be applied in your website within an hour of being
 released by our team.
 
-All security updates will be digitally signed with a secret key to 
+All security updates will be digitally signed with a secret key to
 guarantee authenticity; the associated public key is packaged with the
 default Airship configuration. The digital signature algorithm we use is
 **`Ed25519`** (facilitated by libsodium).
 
 We take extra care when handling our secret key; should it ever be
-compromised, we will use our backup key to revoke the old one and 
+compromised, we will use our backup key to revoke the old one and
 replace it with a new one.
 
 You can disable the auto-update feature from the Bridge, but we do not
 recommend doing this.
 
-You can also choose to trust someone else's mirrors and public key 
-instead of ours. The code is completely open, but you only need change a 
+You can also choose to trust someone else's mirrors and public key
+instead of ours. The code is completely open, but you only need change a
 JSON configuration file to decide to trust someone else.
 
 ### 2. The community is always in control of any add-ons it produces.
@@ -37,17 +37,17 @@ JSON configuration file to decide to trust someone else.
 Airship offers three strategies for extending its base features:
 
 1. Cabins, which are entire applications (see #3 below).
-2. Gadgets, which are plugins that can be applied at a per-Cabin level 
+2. Gadgets, which are plugins that can be applied at a per-Cabin level
    or across every Cabin in your ship.
-3. Motifs, which change the look and feel of your Airship. 
+3. Motifs, which change the look and feel of your Airship.
 
 All Cabins, Gadgets, and Motifs can be assigned to a vendor (which has
-its own Ed25519 key pair), and that supplier has control of the 
+its own Ed25519 key pair), and that supplier has control of the
 distribution of automatic updates.
 
-**This gives you, the supplier, control over your add-ons**, not us. 
+**This gives you, the supplier, control over your add-ons**, not us.
 Neither the Airship development team nor Paragon Initiative Enterprises
-can prevent your users from installing, updating, or using any add-on. 
+can prevent your users from installing, updating, or using any add-on.
 
 We *can* still de-list abusive add-ons from the official SkyPort, but
 anyone can operate their own and we will always aspire to make switching
@@ -58,7 +58,7 @@ barriers to entry.
 
 ### 3. Supports a multi-site architecture out of the box.
 
-Each Cabin is its own website. Install as many Cabins as you need. No 
+Each Cabin is its own website. Install as many Cabins as you need. No
 questionable hacks needed.
 
 ### 4. Designed by progressive-minded application security professionals.
@@ -68,9 +68,9 @@ We specialize in application security and applied cryptography.
 
 ### 5. Our Gear system allows the framework to be extended.
 
-Because of our auto-updater, any local changes made to the Engine files 
+Because of our auto-updater, any local changes made to the Engine files
 will be obliterated whenever an upstream change occurs. To allow users
-to extend and customize the core classes to meet their needs, we 
+to extend and customize the core classes to meet their needs, we
 designed our application around the `Gears` system.
 
 Most of the core `Engine` classes can be extended at runtime by the
@@ -83,7 +83,7 @@ accessing the core classes directly, load the latest version of the Gear
 Compare, for example, [this long guide to securing WordPress](https://codex.wordpress.org/Hardening_WordPress)
 with our guide to securing Airship:
 
-1. Use TLS (if you use [Caddy](https://github.com/paragonie/airship-docs/blob/master/en-us/01-intro/2-Installing.md#caddy-recommended),
+1. Use TLS (if you use [Caddy](https://github.com/paragonie/airship/tree/master/docs/en-us/01-intro/2-Installing.md#caddy-recommended),
    this is automatic in production environments).
 2. Don't disable automatic updates.
 3. Use a strong password.
@@ -95,7 +95,7 @@ of Service attacks. Even if our infrastrucutre is compromised, your Airship is
 protected by [strong cryptography](https://paragonie.com/blog/2016/05/keyggdrasil-continuum-cryptography-powering-cms-airship).
 
 ### Vulnerabilities we Prevent
- 
+
 What follows is a list of security vulnerabilities you will almost certainly
 never have to worry about if you use CMS Airship.
 
@@ -103,7 +103,7 @@ never have to worry about if you use CMS Airship.
   * Airship uses a virtual filesystem that offers read-only access (and only
     to authorized users) to uploaded files. Files will never execute in the
     server nor in your browser.
-* **SQL Injection** is effectively mitigated by our use of prepared 
+* **SQL Injection** is effectively mitigated by our use of prepared
   statements in nearly every context. Where prepared statements aren't
   used, a typecast to int or strict whitelist of allowed characters is
   enforced instead.

--- a/src/Cabin/Bridge/Controller/IndexPage.php
+++ b/src/Cabin/Bridge/Controller/IndexPage.php
@@ -286,7 +286,7 @@ class IndexPage extends ControllerGear
             );
         } else {
             // Not a registered user? Go read the docs. No info leaks for you!
-            \Airship\redirect('https://github.com/paragonie/airship-docs');
+            \Airship\redirect('https://github.com/paragonie/airship/tree/master/docs');
         }
     }
 

--- a/src/Cabin/Bridge/View/cargo/bridge_menu.twig
+++ b/src/Cabin/Bridge/View/cargo/bridge_menu.twig
@@ -229,7 +229,7 @@
         </a>
         <ul>
             <li>
-                <a href="https://github.com/paragonie/airship-docs">
+                <a href="https://github.com/paragonie/airship/tree/master/docs">
                     <i class="fa fa-book bridge-icon"></i>{{  __("Documentation") }}
                 </a>
             </li>

--- a/src/Cabin/Bridge/View/help.twig
+++ b/src/Cabin/Bridge/View/help.twig
@@ -10,7 +10,7 @@
     </p>
     <ul>
         <li>
-            <a href="https://github.com/paragonie/airship-docs">
+            <a href="https://github.com/paragonie/airship/tree/master/docs">
                 <i class="fa fa-book icon-pad-right"></i>{#
                 #}{{ __("Read the Airship Documentation") }}{#
             #}</a>

--- a/src/Installer/skins/base.twig
+++ b/src/Installer/skins/base.twig
@@ -31,7 +31,7 @@
                 &bull;
             <a href="https://github.com/paragonie/airship">Open Source</a>
                 &bull;
-            <a href="https://github.com/paragonie/airship-docs">Online Documentation</a>
+            <a href="https://github.com/paragonie/airship/tree/master/docs">Online Documentation</a>
             </span>
         {% endblock %}</footer>
     {% endblock %}

--- a/src/error_pages/no-cabin.html
+++ b/src/error_pages/no-cabin.html
@@ -28,7 +28,7 @@
             <li>The Cabin configured for this URL was disabled.</li>
         </ol>
         <p>
-            Please refer to the <a href="https://github.com/paragonie/airship-docs">CMS Airship documentation</a>
+            Please refer to the <a href="https://github.com/paragonie/airship/tree/master/docs">CMS Airship documentation</a>
             to learn how to resolve this issue.
         </p>
         <hr />


### PR DESCRIPTION
### Summary

Some links pointed to the archived paragonie/airship-docs repository. Now they all use the paragonie/airship `docs` folder.

## Contributor Agreement (Required)

I am submitting this pull request under one or more of the following
licenses:

- [X] [CC0 - No Rights Reserved](https://creativecommons.org/publicdomain/zero/1.0/)
- [ ] [MIT License](https://opensource.org/licenses/MIT)
- [ ] [WTFPL](http://www.wtfpl.net/txt/copying/)

Furthermore, I understand that CMS Airship is released under the GNU Public
License to the general public, as well as private commercial licenses 
(purchasable from [Paragon Initiative Enterprises](https://paragonie.com)).

By submitting this pull request, I acknowledge that my contribution will be
incorporated into CMS Airship, and consent for it to be handled as outlined
above.

(This does not in any way restrict your rights to use your own modifications.
The purpose of this agreement is to maximize awareness and transparency.) 